### PR TITLE
Refactor: Rename urlPath to url for consistency

### DIFF
--- a/app/mdx/mdx-routes.ts
+++ b/app/mdx/mdx-routes.ts
@@ -9,7 +9,7 @@ import {
 export async function routesAsync(componentPath: string) {
   const manifest = await generateMdxManifest();
   return manifest.files.map((file) =>
-    route(file.urlPath, componentPath, {
+    route(file.url, componentPath, {
       id: file.slug,
     }),
   );
@@ -18,7 +18,7 @@ export async function routesAsync(componentPath: string) {
 export function routes(componentPath: string) {
   const manifest = generateMdxManifestSync();
   return manifest.files.map((file) =>
-    route(file.urlPath, componentPath, {
+    route(file.url, componentPath, {
       id: file.slug,
     }),
   );

--- a/app/mdx/mdx-runtime.ts
+++ b/app/mdx/mdx-runtime.ts
@@ -14,7 +14,7 @@ export async function loadMdxRuntime(
   const { files } = await getRuntimeMdxManifest();
   const mdxFile = files.find(
     (file) =>
-      file.urlPath === pathname || file.urlPath === pathname.replace(/\/$/, ""),
+      file.url === pathname || file.url === pathname.replace(/\/$/, ""),
   );
 
   if (!mdxFile) {
@@ -36,7 +36,7 @@ export async function loadAllMdxRuntime(
 
   if (filterByPaths && filterByPaths.length > 0) {
     filteredFiles = files.filter((file) =>
-      filterByPaths.some((path) => file.urlPath.startsWith(`/${path}/`)),
+      filterByPaths.some((path) => file.url.startsWith(`/${path}/`)),
     );
   }
 
@@ -47,7 +47,7 @@ export async function loadAllMdxRuntime(
     return {
       path: file.path,
       slug: file.slug,
-      urlPath: file.urlPath,
+      url: file.url,
       title: attributes.title || "Untitled",
       description: attributes.description,
       date,

--- a/app/mdx/mdx-runtime.ts
+++ b/app/mdx/mdx-runtime.ts
@@ -13,8 +13,7 @@ export async function loadMdxRuntime(
 
   const { files } = await getRuntimeMdxManifest();
   const mdxFile = files.find(
-    (file) =>
-      file.url === pathname || file.url === pathname.replace(/\/$/, ""),
+    (file) => file.url === pathname || file.url === pathname.replace(/\/$/, ""),
   );
 
   if (!mdxFile) {

--- a/app/mdx/mdx.server.ts
+++ b/app/mdx/mdx.server.ts
@@ -3,7 +3,7 @@ import { glob, globSync } from "glob";
 import {
   processFile,
   processFileAsync,
-  transformFilePathToUrlPath,
+  transformFilePathToUrl,
 } from "../../lib/mdx-utils";
 import type { MdxFile, MdxManifest, PostFrontmatter } from "./types";
 
@@ -50,7 +50,7 @@ export async function generateMdxManifest(): Promise<MdxManifest> {
 
   for (const filePath of pathsFiles[0]) {
     const { attributes, rawContent } = await processMdxFile(filePath);
-    const urlPath = transformFilePathToUrlPath(
+    const url = transformFilePathToUrl(
       filePath,
       resolve(process.cwd(), POSTS_PATH),
     );
@@ -65,7 +65,7 @@ export async function generateMdxManifest(): Promise<MdxManifest> {
     files.push({
       path: filePath,
       slug,
-      urlPath,
+      url,
       attributes,
       rawContent,
     });
@@ -84,7 +84,7 @@ export function generateMdxManifestSync(): MdxManifest {
 
   for (const filePath of pathsFiles[0]) {
     const { attributes } = processMdxFileSync(filePath);
-    const urlPath = transformFilePathToUrlPath(
+    const url = transformFilePathToUrl(
       filePath,
       resolve(process.cwd(), POSTS_PATH),
     );
@@ -99,7 +99,7 @@ export function generateMdxManifestSync(): MdxManifest {
     files.push({
       path: filePath,
       slug,
-      urlPath,
+      url,
       attributes,
       rawContent: "", // Will be loaded when needed
     });
@@ -113,13 +113,13 @@ export async function getMdxFileByUrl(
 ): Promise<MdxFile | undefined> {
   const manifest = await generateMdxManifest();
   return manifest.files.find(
-    (file) => file.urlPath === url || file.urlPath === url.replace(/\/$/, ""),
+    (file) => file.url === url || file.url === url.replace(/\/$/, ""),
   );
 }
 
 export function getMdxFileByUrlSync(url: string): MdxFile | undefined {
   const manifest = generateMdxManifestSync();
   return manifest.files.find(
-    (file) => file.urlPath === url || file.urlPath === url.replace(/\/$/, ""),
+    (file) => file.url === url || file.url === url.replace(/\/$/, ""),
   );
 }

--- a/app/mdx/types.ts
+++ b/app/mdx/types.ts
@@ -8,7 +8,7 @@ export interface MdxOptions {
 export interface MdxFile {
   path: string;
   slug: string;
-  urlPath: string;
+  url: string;
   attributes: PostFrontmatter;
   rawContent: string;
 }
@@ -20,7 +20,7 @@ export interface MdxManifest {
 export interface Post {
   slug: string;
   path: string;
-  urlPath: string;
+  url: string;
   title: string;
   description?: string;
   date?: Date;

--- a/app/routes/__tests__/index.test.tsx
+++ b/app/routes/__tests__/index.test.tsx
@@ -8,7 +8,7 @@ vi.mock("~/mdx/mdx-runtime", () => ({
   loadAllMdxRuntime: vi.fn().mockResolvedValue([
     {
       slug: "test-post-1",
-      urlPath: "/test-post-1",
+      url: "/test-post-1",
       title: "First Test Post",
       description: "First description",
       date: new Date("2024-01-15"),
@@ -21,7 +21,7 @@ vi.mock("~/mdx/mdx-runtime", () => ({
     },
     {
       slug: "test-post-2",
-      urlPath: "/test-post-2",
+      url: "/test-post-2",
       title: "Second Test Post",
       description: "Second description",
       date: new Date("2024-02-20"),

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -45,7 +45,7 @@ export default function Index() {
                   title={post.title}
                   description={post.description}
                   caption={dateCaption}
-                  href={post.urlPath}
+                  href={post.url}
                 />
               );
             })

--- a/app/routes/resources/posts.tsx
+++ b/app/routes/resources/posts.tsx
@@ -16,7 +16,7 @@ export async function loader() {
   // Map to JSON-friendly format
   const postsData = sortedPosts.slice(0, 10).map((post) => ({
     slug: post.slug,
-    url: `https://code.charliegleason.com${post.urlPath}`,
+    url: `https://code.charliegleason.com${post.url}`,
     title: post.title,
     description: post.description,
     date: post.date?.toISOString(),

--- a/app/routes/resources/rss.tsx
+++ b/app/routes/resources/rss.tsx
@@ -57,7 +57,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
     ${postsWithHtml
       .map(({ file, html }) => {
-        const postUrl = `${baseUrl}${file.urlPath}`;
+        const postUrl = `${baseUrl}${file.url}`;
         const date = new Date(file.attributes.date);
         const pubDate = date.toUTCString();
 

--- a/lib/mdx-plugin.ts
+++ b/lib/mdx-plugin.ts
@@ -96,10 +96,7 @@ export const mdxRoutes = [];`;
 
         return `import { route } from "@react-router/dev/routes";
 export const mdxRoutes = [${routes
-          .map(
-            (r) =>
-              `route("${r.url}", "routes/post.tsx", { id: "${r.id}" })`,
-          )
+          .map((r) => `route("${r.url}", "routes/post.tsx", { id: "${r.id}" })`)
           .join(",\n  ")}];`;
       }
     },

--- a/lib/mdx-plugin.ts
+++ b/lib/mdx-plugin.ts
@@ -90,15 +90,15 @@ export const mdxRoutes = [];`;
         }
 
         const routes = manifest.files.map((file) => ({
-          urlPath: file.urlPath,
-          id: file.urlPath.replace("/", ""),
+          url: file.url,
+          id: file.url.replace("/", ""),
         }));
 
         return `import { route } from "@react-router/dev/routes";
 export const mdxRoutes = [${routes
           .map(
             (r) =>
-              `route("${r.urlPath}", "routes/post.tsx", { id: "${r.id}" })`,
+              `route("${r.url}", "routes/post.tsx", { id: "${r.id}" })`,
           )
           .join(",\n  ")}];`;
       }

--- a/lib/mdx-utils.ts
+++ b/lib/mdx-utils.ts
@@ -6,7 +6,7 @@ import matter from "gray-matter";
 export interface ContentFile<T = Record<string, unknown>> {
   path: string;
   slug: string;
-  urlPath: string;
+  url: string;
   attributes: T;
   rawContent: string;
 }
@@ -33,7 +33,7 @@ function parseFilenameParts(filename: string): {
   return { slug };
 }
 
-export function transformFilePathToUrlPath(
+export function transformFilePathToUrl(
   filePath: string,
   basePath: string,
   alias?: string,
@@ -211,7 +211,7 @@ export function generateManifest(
         addWatchFile?.(filePath);
 
         const { attributes, rawContent } = processFile(filePath);
-        const urlPath = transformFilePathToUrlPath(filePath, basePath);
+        const url = transformFilePathToUrl(filePath, basePath);
 
         // Use the slug from attributes (which includes filename parsing)
         const slug = `${
@@ -226,7 +226,7 @@ export function generateManifest(
         manifest.files.push({
           path: filePath,
           slug,
-          urlPath,
+          url,
           attributes,
           rawContent,
         });


### PR DESCRIPTION
## Problem

The property name `urlPath` was inconsistent with common naming conventions and could be confusing. In web development, "url" typically refers to the complete web address, while this property actually stores just the path portion. However, the term `urlPath` is redundant - a simpler `url` is clearer and more commonly used in routing contexts.

## Solution

Renamed all instances of `urlPath` to `url` throughout the codebase for consistency and clarity. This affects:

- Type definitions in `app/mdx/types.ts`
- MDX manifest generation in `app/mdx/mdx.server.ts`
- Route generation in `app/mdx/mdx-routes.ts` and `lib/mdx-plugin.ts`
- Runtime loading in `app/mdx/mdx-runtime.ts`
- Route components using the property (`app/routes/index.tsx`, RSS feed, etc.)
- Utility functions in `lib/mdx-utils.ts` (renamed `transformFilePathToUrlPath` to `transformFilePathToUrl`)
- Test fixtures

This is a straightforward rename with no functional changes - all behavior remains the same.