### PR TITLE
Reduce visual variations from 21 to 9 for improved performance

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,8 @@
       "Bash(head:*)",
       "Bash(done)",
       "Bash(npm test:*)",
-      "Bash(npm view:*)"
+      "Bash(npm view:*)",
+      "Bash(git log:*)"
     ],
     "deny": [],
     "ask": []

--- a/app/components/__tests__/nav-block.test.tsx
+++ b/app/components/__tests__/nav-block.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VISUAL_COUNT } from "~/config/constants";
 import NavBlock from "../nav-block";
 
 // Mock framer-motion to avoid animation complexity in tests
@@ -22,14 +23,22 @@ vi.mock("framer-motion", () => ({
 }));
 
 // Mock video index utilities
-vi.mock("~/utils/video-index", () => ({
-  randomVideoIndexExcluding: vi.fn((current: number) => (current + 1) % 21),
-  toUserIndex: vi.fn((internal: number) => internal + 1),
-  preloadVideo: vi.fn(
-    (slug: string, index: number) => `preload-${slug}-${index}`,
-  ),
-  cleanupPreloadedVideo: vi.fn(),
-}));
+vi.mock("~/utils/video-index", async () => {
+  const { VISUAL_COUNT } =
+    await vi.importActual<typeof import("~/config/constants")>(
+      "~/config/constants",
+    );
+  return {
+    randomVideoIndexExcluding: vi.fn(
+      (current: number) => (current + 1) % VISUAL_COUNT,
+    ),
+    toUserIndex: vi.fn((internal: number) => internal + 1),
+    preloadVideo: vi.fn(
+      (slug: string, index: number) => `preload-${slug}-${index}`,
+    ),
+    cleanupPreloadedVideo: vi.fn(),
+  };
+});
 
 describe("NavBlock", () => {
   const defaultProps = {

--- a/app/components/video-masthead.tsx
+++ b/app/components/video-masthead.tsx
@@ -6,7 +6,7 @@ import { extractModelName } from "~/utils/replicate";
 import {
   randomVideoIndexExcluding,
   toUserIndex,
-  VIDEO_COUNT,
+  VISUAL_COUNT,
 } from "~/utils/video-index";
 import IconSwapAnimation from "./icon-swap-animation";
 
@@ -99,7 +99,7 @@ export default function VideoMasthead({
             </motion.div>
 
             <span className="text-gray-400 dark:text-gray-500">
-              {String(toUserIndex(currentVideo)).padStart(2, "0")}/{VIDEO_COUNT}
+              {toUserIndex(currentVideo)}/{VISUAL_COUNT}
             </span>
           </button>
           <button

--- a/app/config/constants.ts
+++ b/app/config/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Application-wide constants
+ * This file contains constants used across both the app and scripts
+ */
+
+/**
+ * Number of video/image variations generated per post
+ * Images/videos are stored as 0-(VISUAL_COUNT-1)
+ * User-facing URLs display as 1-VISUAL_COUNT
+ */
+export const VISUAL_COUNT = 9;

--- a/app/routes/__tests__/post.test.tsx
+++ b/app/routes/__tests__/post.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VISUAL_COUNT } from "~/config/constants";
 import type { Route } from "../+types/post";
 import { loader } from "../post";
 
@@ -22,15 +23,22 @@ vi.mock("~/utils/kudos.server", () => ({
   getKudosCookie: vi.fn(() => 5),
 }));
 
-vi.mock("~/utils/video-index", () => ({
-  parseImageIndex: vi.fn((val: string | null) => {
-    if (val === null) return null;
-    const num = Number.parseInt(val, 10);
-    if (Number.isNaN(num) || num < 1 || num > 21) return null;
-    return num - 1; // Convert user index to internal
-  }),
-  randomVideoIndex: vi.fn(() => 10),
-}));
+vi.mock("~/utils/video-index", async () => {
+  const { VISUAL_COUNT } =
+    await vi.importActual<typeof import("~/config/constants")>(
+      "~/config/constants",
+    );
+  return {
+    VISUAL_COUNT,
+    parseImageIndex: vi.fn((val: string | null) => {
+      if (val === null) return null;
+      const num = Number.parseInt(val, 10);
+      if (Number.isNaN(num) || num < 1 || num > VISUAL_COUNT) return null;
+      return num - 1; // Convert user index to internal
+    }),
+    randomVideoIndex: vi.fn(() => Math.floor(VISUAL_COUNT / 2)),
+  };
+});
 
 describe("Post Route Loader", () => {
   const mockContext = {
@@ -62,18 +70,18 @@ describe("Post Route Loader", () => {
 
   describe("video index priority logic", () => {
     it("should use URL param when provided (share link)", async () => {
-      const mockRequest = new Request("http://localhost:3000/test-post/15", {
+      const mockRequest = new Request("http://localhost:3000/test-post/7", {
         headers: { Cookie: "visual-index-test-post=5" },
       });
 
       const response = await loader({
         request: mockRequest,
         context: mockContext,
-        params: { index: "15" },
+        params: { index: "7" },
       } as unknown as Route.LoaderArgs);
 
-      // URL param 15 converts to internal index 14 (15 - 1)
-      expect(response.data.randomVideo).toBe(14);
+      // URL param 7 converts to internal index 6 (7 - 1)
+      expect(response.data.randomVideo).toBe(6);
     });
 
     it("should use cookie when present and delete it", async () => {
@@ -116,9 +124,9 @@ describe("Post Route Loader", () => {
         params: {},
       } as unknown as Route.LoaderArgs);
 
-      // Should call randomVideoIndex and use its value (10)
+      // Should call randomVideoIndex and use its value (Math.floor(VISUAL_COUNT / 2) = 4)
       expect(randomVideoIndex).toHaveBeenCalled();
-      expect(response.data.randomVideo).toBe(10);
+      expect(response.data.randomVideo).toBe(Math.floor(VISUAL_COUNT / 2));
     });
 
     it("should prefer cookie over random generation when cookie exists", async () => {
@@ -159,9 +167,9 @@ describe("Post Route Loader", () => {
         params: { index: "999" },
       } as unknown as Route.LoaderArgs);
 
-      // Should call randomVideoIndex when param is invalid
+      // Should call randomVideoIndex when param is invalid (Math.floor(VISUAL_COUNT / 2) = 4)
       expect(randomVideoIndex).toHaveBeenCalled();
-      expect(response.data.randomVideo).toBe(10);
+      expect(response.data.randomVideo).toBe(Math.floor(VISUAL_COUNT / 2));
     });
 
     it("should return undefined randomVideo when no visual config", async () => {

--- a/app/routes/post.tsx
+++ b/app/routes/post.tsx
@@ -15,7 +15,7 @@ import { highlightCode } from "~/utils/shiki.server";
 import {
   parseImageIndex,
   randomVideoIndex,
-  VIDEO_COUNT,
+  VISUAL_COUNT,
 } from "~/utils/video-index";
 import { loadMdxRuntime } from "../mdx/mdx-runtime";
 import type { Route } from "./+types/post";
@@ -67,13 +67,13 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
     const match = cookieHeader.match(new RegExp(`${cookieName}=([^;]+)`));
     if (match) {
       const value = Number.parseInt(match[1], 10);
-      if (!Number.isNaN(value) && value >= 0 && value <= 20) {
+      if (!Number.isNaN(value) && value >= 0 && value < VISUAL_COUNT) {
         cookieIndex = value;
       }
     }
   }
 
-  // Determine which video to show (0-20 internal index)
+  // Determine which video to show (internal index)
   // Priority: URL param > Cookie > Random
   let randomVideo: number | undefined;
   let shouldDeleteCookie = false;
@@ -120,7 +120,7 @@ export function meta({ data, params }: Route.MetaArgs) {
   const imageParam =
     "index" in params ? (params.index as string | undefined) : undefined;
   const parsedIndex = parseImageIndex(imageParam ?? null);
-  // Convert internal index (0-20) back to user-facing (1-21) for meta tags
+  // Convert internal index back to user-facing for meta tags
   return tags(attributes, parsedIndex !== null ? parsedIndex + 1 : undefined);
 }
 
@@ -140,12 +140,12 @@ export default function Post() {
   const { title, data, links, date, slug, visual } = useMdxAttributes();
   const { metadata, isOldArticle } = processArticleDate(data, date);
 
-  // Preload all 21 videos on mount for instant transitions on refresh button
+  // Preload all videos on mount for instant transitions on refresh button
   useEffect(() => {
     if (!slug || !visual) return;
 
     // Preload all videos using fetch with low priority
-    for (let i = 0; i < VIDEO_COUNT; i++) {
+    for (let i = 0; i < VISUAL_COUNT; i++) {
       fetch(`/posts/${slug}/${i}.mp4`, {
         priority: "low",
       } as RequestInit).catch(() => {});

--- a/app/routes/resources/og-image.tsx
+++ b/app/routes/resources/og-image.tsx
@@ -41,7 +41,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const { slug } = params;
 
   // Get image index from path parameter (e.g., /slug/1.png)
-  // Convert from user-facing (1-21) to internal (0-20)
+  // Convert from user-facing to internal index
   // The index param is optional - only present for indexed OG images
   const imageParam = "index" in params ? params.index : undefined;
   const imageIndex = parseImageIndex(imageParam);
@@ -76,7 +76,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     // If visual is missing, fall back to text-only layout
     if (post.frontmatter.visual) {
       try {
-        // Use query parameter if provided, otherwise random selection (0-20)
+        // Use query parameter if provided, otherwise random selection
         const selectedIndex =
           imageIndex !== null ? imageIndex : randomVideoIndex();
         const aiImagePath = `/posts/${slug}/${selectedIndex}.png`;

--- a/app/routes/social-grid.tsx
+++ b/app/routes/social-grid.tsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { useLoaderData } from "react-router";
 import tags from "~/components/utils/tags";
+import { VISUAL_COUNT } from "~/config/constants";
 import { loadMdxRuntime } from "~/mdx/mdx-runtime";
 import type { Route } from "./+types/social-grid";
 
@@ -79,13 +80,13 @@ function VideoCard({
 export default function SocialGrid() {
   const { slug } = useLoaderData<typeof loader>();
 
-  // Generate array of image indices (0-20)
-  const imageIndices = Array.from({ length: 21 }, (_, i) => i);
+  // Generate array of image indices
+  const imageIndices = Array.from({ length: VISUAL_COUNT }, (_, i) => i);
 
   return (
     <div className="grid grid-cols-3 gap-4">
       {imageIndices.map((index) => {
-        // Convert internal index (0-20) to user-facing (1-21) for URLs
+        // Convert internal index to user-facing for URLs
         const userIndex = index + 1;
         const imageUrl = `/${slug}/${userIndex}.png`;
         const videoUrl = `/posts/${slug}/${index}.mp4`;

--- a/app/utils/__tests__/video-index.test.ts
+++ b/app/utils/__tests__/video-index.test.ts
@@ -7,23 +7,23 @@ import {
   parseImageIndex,
   randomVideoIndex,
   toUserIndex,
-  VIDEO_COUNT,
+  VISUAL_COUNT,
 } from "../video-index";
 
 describe("video-index utilities", () => {
   describe("constants", () => {
-    it("should have correct VIDEO_COUNT", () => {
-      expect(VIDEO_COUNT).toBe(21);
+    it("should have correct VISUAL_COUNT", () => {
+      expect(VISUAL_COUNT).toBe(9);
     });
 
     it("should have correct user index range", () => {
       expect(MIN_USER_INDEX).toBe(1);
-      expect(MAX_USER_INDEX).toBe(21);
+      expect(MAX_USER_INDEX).toBe(9);
     });
 
     it("should have correct internal index range", () => {
       expect(MIN_INTERNAL_INDEX).toBe(0);
-      expect(MAX_INTERNAL_INDEX).toBe(20);
+      expect(MAX_INTERNAL_INDEX).toBe(8);
     });
   });
 
@@ -35,7 +35,7 @@ describe("video-index utilities", () => {
     it("should convert valid user index to internal index", () => {
       expect(parseImageIndex("1")).toBe(0);
       expect(parseImageIndex("5")).toBe(4);
-      expect(parseImageIndex("21")).toBe(20);
+      expect(parseImageIndex("9")).toBe(8);
     });
 
     it("should return null for index below minimum (0)", () => {
@@ -46,8 +46,8 @@ describe("video-index utilities", () => {
       expect(parseImageIndex("-1")).toBe(null);
     });
 
-    it("should return null for index above maximum (22+)", () => {
-      expect(parseImageIndex("22")).toBe(null);
+    it("should return null for index above maximum (10+)", () => {
+      expect(parseImageIndex("10")).toBe(null);
       expect(parseImageIndex("100")).toBe(null);
     });
 
@@ -65,7 +65,7 @@ describe("video-index utilities", () => {
 
     it("should handle boundary values correctly", () => {
       expect(parseImageIndex("1")).toBe(0); // Min valid
-      expect(parseImageIndex("21")).toBe(20); // Max valid
+      expect(parseImageIndex("9")).toBe(8); // Max valid
     });
 
     it("should handle string numbers with whitespace", () => {
@@ -73,9 +73,9 @@ describe("video-index utilities", () => {
     });
 
     it("should handle valid middle range values", () => {
-      expect(parseImageIndex("10")).toBe(9);
-      expect(parseImageIndex("11")).toBe(10);
-      expect(parseImageIndex("15")).toBe(14);
+      expect(parseImageIndex("5")).toBe(4);
+      expect(parseImageIndex("6")).toBe(5);
+      expect(parseImageIndex("7")).toBe(6);
     });
   });
 
@@ -83,7 +83,7 @@ describe("video-index utilities", () => {
     it("should convert internal index to user index", () => {
       expect(toUserIndex(0)).toBe(1);
       expect(toUserIndex(5)).toBe(6);
-      expect(toUserIndex(20)).toBe(21);
+      expect(toUserIndex(8)).toBe(9);
     });
 
     it("should handle boundary values", () => {
@@ -144,7 +144,7 @@ describe("video-index utilities", () => {
 
   describe("integration tests", () => {
     it("should round-trip conversion work correctly", () => {
-      for (let internal = 0; internal <= 20; internal++) {
+      for (let internal = 0; internal <= 8; internal++) {
         const user = toUserIndex(internal);
         const backToInternal = parseImageIndex(user.toString());
         expect(backToInternal).toBe(internal);
@@ -152,11 +152,11 @@ describe("video-index utilities", () => {
     });
 
     it("should handle all valid user inputs correctly", () => {
-      for (let user = 1; user <= 21; user++) {
+      for (let user = 1; user <= 9; user++) {
         const internal = parseImageIndex(user.toString());
         expect(internal).not.toBe(null);
         expect(internal).toBeGreaterThanOrEqual(0);
-        expect(internal).toBeLessThanOrEqual(20);
+        expect(internal).toBeLessThanOrEqual(8);
       }
     });
 
@@ -175,7 +175,7 @@ describe("video-index utilities", () => {
       expect(MAX_USER_INDEX - MIN_USER_INDEX).toBe(
         MAX_INTERNAL_INDEX - MIN_INTERNAL_INDEX,
       );
-      expect(MAX_USER_INDEX - MIN_USER_INDEX + 1).toBe(VIDEO_COUNT);
+      expect(MAX_USER_INDEX - MIN_USER_INDEX + 1).toBe(VISUAL_COUNT);
     });
   });
 });

--- a/app/utils/video-index.ts
+++ b/app/utils/video-index.ts
@@ -1,27 +1,31 @@
+import { VISUAL_COUNT as VISUAL_COUNT_CONSTANT } from "~/config/constants";
+
 /**
  * Utilities for handling video/image index conversion and validation.
- * Images and videos are stored as 0-20 (21 total files).
- * User-facing URLs and UI display as 1-21.
+ * Images and videos are stored as 0-(VISUAL_COUNT-1).
+ * User-facing URLs and UI display as 1-VISUAL_COUNT.
  */
 
-export const VIDEO_COUNT = 21;
+// Re-export VISUAL_COUNT for convenience
+export const VISUAL_COUNT = VISUAL_COUNT_CONSTANT;
+
 export const MIN_USER_INDEX = 1;
-export const MAX_USER_INDEX = VIDEO_COUNT;
+export const MAX_USER_INDEX = VISUAL_COUNT;
 export const MIN_INTERNAL_INDEX = 0;
-export const MAX_INTERNAL_INDEX = VIDEO_COUNT - 1;
+export const MAX_INTERNAL_INDEX = VISUAL_COUNT - 1;
 
 /**
  * Parse and validate an image query parameter.
- * Converts from user-facing index (1-21) to internal index (0-20).
+ * Converts from user-facing index to internal index.
  *
- * @param imageParam - The raw query parameter value from URL (e.g., "1", "21", "invalid")
- * @returns The internal index (0-20) if valid, null if invalid or not provided
+ * @param imageParam - The raw query parameter value from URL
+ * @returns The internal index if valid, null if invalid or not provided
  *
  * @example
  * parseImageIndex("1") // 0
- * parseImageIndex("21") // 20
+ * parseImageIndex("9") // 8
  * parseImageIndex("0") // null (invalid)
- * parseImageIndex("22") // null (out of range)
+ * parseImageIndex("10") // null (out of range)
  * parseImageIndex("abc") // null (not a number)
  * parseImageIndex(null) // null (not provided)
  */
@@ -36,7 +40,7 @@ export function parseImageIndex(imageParam: unknown | null): number | null {
 
   const parsed = parseInt(imageParam, 10);
 
-  // Validate: must be a valid number between 1-21
+  // Validate: must be a valid number in the user-facing range
   if (
     Number.isNaN(parsed) ||
     parsed < MIN_USER_INDEX ||
@@ -45,41 +49,41 @@ export function parseImageIndex(imageParam: unknown | null): number | null {
     return null;
   }
 
-  // Convert from user-facing (1-21) to internal (0-20)
+  // Convert from user-facing to internal index
   return parsed - 1;
 }
 
 /**
- * Convert internal index (0-20) to user-facing index (1-21).
+ * Convert internal index to user-facing index.
  *
- * @param internalIndex - The internal index (0-20)
- * @returns The user-facing index (1-21)
+ * @param internalIndex - The internal index
+ * @returns The user-facing index
  *
  * @example
  * toUserIndex(0) // 1
- * toUserIndex(20) // 21
+ * toUserIndex(8) // 9
  */
 export function toUserIndex(internalIndex: number): number {
   return internalIndex + 1;
 }
 
 /**
- * Generate a random internal index (0-20).
+ * Generate a random internal index.
  *
  * @returns A random internal index
  */
 export function randomVideoIndex(): number {
-  return Math.floor(Math.random() * VIDEO_COUNT);
+  return Math.floor(Math.random() * VISUAL_COUNT);
 }
 
 /**
- * Generate a random internal index (0-20) that's different from the current index.
+ * Generate a random internal index that's different from the current index.
  *
  * @param currentIndex - The current internal index to exclude
  * @returns A random internal index different from currentIndex
  *
  * @example
- * randomVideoIndexExcluding(5) // returns 0-20 but never 5
+ * randomVideoIndexExcluding(5) // returns a random index but never 5
  */
 export function randomVideoIndexExcluding(currentIndex: number): number {
   let newIndex = randomVideoIndex();
@@ -94,7 +98,7 @@ export function randomVideoIndexExcluding(currentIndex: number): number {
  * This ensures smooth transitions when the video is displayed.
  *
  * @param slug - The post slug
- * @param videoIndex - The internal video index (0-20) to preload
+ * @param videoIndex - The internal video index to preload
  * @returns The ID of the preloaded video element for later cleanup
  *
  * @example

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { glob } from "glob";
 import matter from "gray-matter";
+import { VISUAL_COUNT } from "../app/config/constants";
 
 export interface ModelConfig {
   url: string;
@@ -21,7 +22,7 @@ export interface PostData {
   visual: VisualConfig;
 }
 
-export const IMAGES_PER_POST = 21; // 0-20
+export const IMAGES_PER_POST = VISUAL_COUNT;
 export const OUTPUT_DIR = "public/posts";
 export const POSTS_DIR = "posts";
 


### PR DESCRIPTION
## Problem

The site was generating 21 visual variations (images/videos) per post, which created:
- Excessive storage requirements
- Longer build times
- Unnecessary resource usage
- More visual options than needed for variety

## Solution

This PR reduces the number of visual variations from 21 to 9 while maintaining adequate visual diversity:

- Created a centralized `VISUAL_COUNT` constant in `app/config/constants.ts`
- Updated `video-index.ts` utility to use the new constant and reflect 0-8 internal indexing (1-9 user-facing)
- Updated all related components and routes:
  - `video-masthead.tsx` - visual selection logic
  - `post.tsx` - route handling
  - `og-image.tsx` - social image generation
  - `social-grid.tsx` - grid display
- Updated all test files to reflect the new count
- Updated scripts to use the shared constant

## Benefits

- 57% reduction in visual assets per post
- Faster build times
- Reduced storage requirements
- Maintained visual variety with 9 distinct options
- Centralized configuration makes future adjustments easier

## Testing

All tests updated and passing with the new visual count.