### PR TITLE
Smooth out video rewind animation easing

### DIFF
--- a/app/components/nav-block.tsx
+++ b/app/components/nav-block.tsx
@@ -96,7 +96,7 @@ export default function NavBlock({
         const progress = Math.min(elapsed / rewindDuration, 1);
 
         // Ease out for smoother motion
-        const easeProgress = 1 - (1 - progress) ** 3;
+        const easeProgress = 1 - (1 - progress) ** 2;
 
         video.currentTime = startTime * (1 - easeProgress);
 


### PR DESCRIPTION
## Problem
The video rewind animation was using a cubic ease-out function (`progress ** 3`), which created a very aggressive deceleration curve. This made the rewind feel too abrupt at the end.

## Solution
Changed the easing function from cubic (`** 3`) to quadratic (`** 2`) for a gentler deceleration. This provides a smoother, more natural-feeling rewind animation while still maintaining the ease-out effect.

### Changes
- Updated `easeProgress` calculation in `app/components/nav-block.tsx:99`
- Changed from `1 - (1 - progress) ** 3` to `1 - (1 - progress) ** 2`