### PR TITLE
Add view transitions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,6 @@
 {
   "permissions": {
-    "allow": [],
+    "allow": ["Bash(npm run lint)", "Bash(npm run lint:fix:*)"],
     "deny": [],
     "ask": []
   }

--- a/app/components/__tests__/nav-block.test.tsx
+++ b/app/components/__tests__/nav-block.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { BrowserRouter } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import NavBlock from "../nav-block";
 
@@ -32,7 +33,11 @@ describe("NavBlock", () => {
   });
 
   it("should render with basic props", () => {
-    render(<NavBlock post={defaultPost} index={5} />);
+    render(
+      <BrowserRouter>
+        <NavBlock post={defaultPost} index={5} />
+      </BrowserRouter>,
+    );
 
     expect(screen.getByText("Test Post Title")).toBeInTheDocument();
     expect(screen.getByText("This is a test description")).toBeInTheDocument();
@@ -40,7 +45,11 @@ describe("NavBlock", () => {
 
   it("should render without optional description", () => {
     const postWithoutDescription = { ...defaultPost, description: undefined };
-    render(<NavBlock post={postWithoutDescription} index={5} />);
+    render(
+      <BrowserRouter>
+        <NavBlock post={postWithoutDescription} index={5} />
+      </BrowserRouter>,
+    );
 
     expect(screen.getByText("Test Post Title")).toBeInTheDocument();
     expect(
@@ -49,7 +58,11 @@ describe("NavBlock", () => {
   });
 
   it("should render image with correct src", () => {
-    const { container } = render(<NavBlock post={defaultPost} index={5} />);
+    const { container } = render(
+      <BrowserRouter>
+        <NavBlock post={defaultPost} index={5} />
+      </BrowserRouter>,
+    );
 
     const img = container.querySelector("img") as HTMLImageElement;
     expect(img).toBeInTheDocument();
@@ -57,7 +70,11 @@ describe("NavBlock", () => {
   });
 
   it("should render link with correct href including video index", () => {
-    render(<NavBlock post={defaultPost} index={5} />);
+    render(
+      <BrowserRouter>
+        <NavBlock post={defaultPost} index={5} />
+      </BrowserRouter>,
+    );
 
     const link = screen.getByRole("link");
     // Should include video index (video 5 + 1 = 6 in user-facing format)
@@ -65,14 +82,22 @@ describe("NavBlock", () => {
   });
 
   it("should have hover effect classes on link", () => {
-    render(<NavBlock post={defaultPost} index={5} />);
+    render(
+      <BrowserRouter>
+        <NavBlock post={defaultPost} index={5} />
+      </BrowserRouter>,
+    );
 
     const link = screen.getByRole("link");
     expect(link).toHaveClass("group");
   });
 
   it("should render all content within link element", () => {
-    render(<NavBlock post={defaultPost} index={5} />);
+    render(
+      <BrowserRouter>
+        <NavBlock post={defaultPost} index={5} />
+      </BrowserRouter>,
+    );
 
     const link = screen.getByRole("link");
     expect(link).toContainElement(screen.getByText("Test Post Title"));
@@ -86,21 +111,33 @@ describe("NavBlock", () => {
       ...defaultPost,
       tags: ["react", "typescript"],
     };
-    render(<NavBlock post={postWithTags} index={5} />);
+    render(
+      <BrowserRouter>
+        <NavBlock post={postWithTags} index={5} />
+      </BrowserRouter>,
+    );
 
     expect(screen.getByText("react")).toBeInTheDocument();
     expect(screen.getByText("typescript")).toBeInTheDocument();
   });
 
   it("should not render tags section when tags are empty", () => {
-    const { container } = render(<NavBlock post={defaultPost} index={5} />);
+    const { container } = render(
+      <BrowserRouter>
+        <NavBlock post={defaultPost} index={5} />
+      </BrowserRouter>,
+    );
 
     // Tags container should not be present
     expect(container.querySelector(".flex-wrap.gap-2")).not.toBeInTheDocument();
   });
 
   it("should apply className", () => {
-    render(<NavBlock post={defaultPost} index={5} className="puppies" />);
+    render(
+      <BrowserRouter>
+        <NavBlock post={defaultPost} index={5} className="puppies" />
+      </BrowserRouter>,
+    );
 
     const link = screen.getByRole("link");
     expect(link).toHaveClass("puppies");
@@ -120,7 +157,11 @@ describe("NavBlock", () => {
         { text: "#555555", background: "#aaaaaa" },
       ],
     };
-    render(<NavBlock post={defaultPost} index={5} visual={visual} />);
+    render(
+      <BrowserRouter>
+        <NavBlock post={defaultPost} index={5} visual={visual} />
+      </BrowserRouter>,
+    );
 
     const link = screen.getByRole("link");
     expect(link).toHaveStyle({

--- a/app/components/about.tsx
+++ b/app/components/about.tsx
@@ -24,6 +24,7 @@ export function About() {
           <Link
             className="inline-flex items-center gap-1 font-semibold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
             to="/about"
+            viewTransition
             onMouseEnter={replay}
             onFocus={replay}
           >

--- a/app/components/frame.tsx
+++ b/app/components/frame.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink } from "react-router";
+import { Link, NavLink, useLocation } from "react-router";
 import { useScramble } from "use-scramble";
 import { scrambleOptions } from "./utils/scramble";
 
@@ -15,13 +15,29 @@ function MenuItem({ to, children }: { to: string; children: string }) {
     ...scrambleOptions,
     text: children.toString(),
   });
+  const location = useLocation();
+
+  // Check if we're already on this page
+  const isCurrentPage = location.pathname === to ||
+    (to === "/" && location.pathname === "/");
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    // If already on this page, just scroll to top without view transition
+    if (isCurrentPage) {
+      e.preventDefault();
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
   return (
     <NavLink
       to={to}
+      viewTransition
       className={navLinkClass}
       ref={ref}
       onMouseEnter={replay}
       onFocus={replay}
+      onClick={handleClick}
     >
       {children}
     </NavLink>
@@ -38,11 +54,15 @@ export function Frame({
   return (
     <div className="grid grid-rows-layout gap-8 min-h-dvh p-4 sm:p-8 [padding-bottom:calc(env(safe-area-inset-bottom)+4.5rem)] sm:[padding-bottom:calc(env(safe-area-inset-bottom)+8rem)] text-indigo-600 dark:text-indigo-400 overflow-x-hidden">
       <div className="content-end">{children}</div>
-      <div className="z-50 fixed inset-x-0 bottom-0 bg-gray-50 dark:bg-gray-900 drop-shadow-2xl font-mono">
+      <div
+        className="z-50 fixed inset-x-0 bottom-0 bg-gray-50 dark:bg-gray-900 drop-shadow-2xl font-mono"
+        style={{ viewTransitionName: 'navigation' }}
+      >
         <div className="flex justify-between border-t dark:border-gray-800 px-8 pt-4 pb-4 sm:pb-12">
           <div className="flex gap-6">
             <Link
               to="/"
+              viewTransition
               className="flex gap-1 leading-tight select-none focus-ring-primary"
             >
               <span>{"❯"}</span>

--- a/app/components/frame.tsx
+++ b/app/components/frame.tsx
@@ -18,8 +18,8 @@ function MenuItem({ to, children }: { to: string; children: string }) {
   const location = useLocation();
 
   // Check if we're already on this page
-  const isCurrentPage = location.pathname === to ||
-    (to === "/" && location.pathname === "/");
+  const isCurrentPage =
+    location.pathname === to || (to === "/" && location.pathname === "/");
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     // If already on this page, just scroll to top without view transition
@@ -56,7 +56,7 @@ export function Frame({
       <div className="content-end">{children}</div>
       <div
         className="z-50 fixed inset-x-0 bottom-0 bg-gray-50 dark:bg-gray-900 drop-shadow-2xl font-mono"
-        style={{ viewTransitionName: 'navigation' }}
+        style={{ viewTransitionName: "navigation" }}
       >
         <div className="flex justify-between border-t dark:border-gray-800 px-8 pt-4 pb-4 sm:pb-12">
           <div className="flex gap-6">

--- a/app/components/metadata.tsx
+++ b/app/components/metadata.tsx
@@ -1,9 +1,18 @@
 import { format, parseISO } from "date-fns";
 import type { MetaData } from "~/mdx/types";
 
-export default function Metadata({ data }: { data?: MetaData[] }) {
+export default function Metadata({
+  data,
+  style,
+}: {
+  data?: MetaData[];
+  style?: React.CSSProperties;
+}) {
   return data?.length ? (
-    <dl className="font-mono text-xs divide-y divide-gray-200 dark:divide-gray-800 border-y border-gray-200 dark:border-gray-800 max-w-xl">
+    <dl
+      className="font-mono text-xs divide-y divide-gray-200 dark:divide-gray-800 border-y border-gray-200 dark:border-gray-800 max-w-xl"
+      style={style}
+    >
       {data.map((item: { key: string; value: string }) => {
         const date = /(\d{4})-(\d{2})-(\d{2})/.exec(item.value);
         return (

--- a/app/components/nav-block.tsx
+++ b/app/components/nav-block.tsx
@@ -20,7 +20,7 @@ export default function NavBlock({
   hero?: boolean;
   oldArticle?: boolean;
 }) {
-  const { title, description, url, slug, tags } = post;
+  const { title, description, url, slug, tags, excerpt } = post;
 
   // Viewport intersection state (starts false to match SSR)
   const elementRef = useRef<HTMLAnchorElement>(null);
@@ -38,10 +38,8 @@ export default function NavBlock({
       }
       className={`nav-block ${hero ? "justify-center" : "justify-between sm:flex-col"} flex-col-reverse @container text-[var(--text)] bg-[var(--background)] overflow-hidden flex group rounded-md relative ring-transparent ring-offset-1 dark:ring-offset-gray-950 hover:ring-[var(--background)] hover:ring-3 focus-visible:ring-[var(--background)] focus-visible:ring-3 outline-none transition-opacity duration-300 ${className}`}
     >
-      <div
-        className={`flex flex-col gap-4 p-4 ${hero ? "flex-0" : "h-auto flex-1 justify-between"}`}
-      >
-        <div className="space-y-2">
+      <div className={`flex flex-col p-4 flex-1 min-h-0 justify-between`}>
+        <div className="space-y-2 sm:space-y-4 flex-shrink-0">
           <div className="flex justify-between relative z-10">
             <div
               className={`max-w-2xl flex w-0 flex-1 flex-col items-start flex-wrap gap-x-2 ${description ? "gap-y-2" : "gap-y-0"}`}
@@ -49,7 +47,7 @@ export default function NavBlock({
               <div className="text-xs relative whitespace-nowrap w-full z-10 flex gap-2 items-center overflow-hidden [mask-image:linear-gradient(to_right,black_calc(100%-2rem),transparent)]">
                 {caption ? (
                   <span
-                    className={`px-1.5 rounded-full ${oldArticle ? "border border-[var(--text)]/30 text-[var(--text)]" : "bg-[var(--text)] text-[var(--background)]"}`}
+                    className={`px-2 rounded-full ${oldArticle ? "border border-[var(--text)]/30 text-[var(--text)]" : "bg-[var(--text)] text-[var(--background)]"}`}
                   >
                     {caption}
                   </span>
@@ -72,20 +70,39 @@ export default function NavBlock({
           </div>
           {description ? (
             <div className="relative z-10">
-              <div className="overflow-hidden text-sm max-w-lg text-current/80 font-mono font-semibold">
+              <div
+                className={`overflow-hidden ${hero ? "sm:text-lg" : "text-sm"} max-w-lg text-current/80 font-mono font-semibold`}
+              >
                 {description}
               </div>
             </div>
           ) : null}
         </div>
+        {hero && excerpt ? (
+          <div className="flex-1 min-h-0 relative overflow-hidden mt-4">
+            <div className="absolute inset-0 flex pointer-events-none">
+              <div className="max-w-2xl text-base text-current/50 leading-relaxed mask-b-from-50% mask-b-to-100% whitespace-pre-wrap h-fit">
+                {excerpt}
+              </div>
+            </div>
+          </div>
+        ) : null}
+        {hero ? (
+          <a
+            href={`${url}/${toUserIndex(index)}`}
+            className="absolute bottom-0 rounded-t-sm self-start px-4 py-2 bg-(--text)/90 text-(--background) font-semibold max-md:hidden"
+          >
+            Read more
+          </a>
+        ) : null}
       </div>
       <div
-        className={`${hero ? "sm:-mb-24" : "sm:mb-0"} -mb-8 flex items-center justify-center relative w-full aspect-square shrink-0 overflow-hidden rounded-md`}
+        className={`${hero ? "sm:-mb-16" : "sm:mb-0"} -mb-8 flex items-center justify-center relative w-full aspect-square shrink-0 overflow-hidden rounded-md`}
       >
         <img
           src={`/posts/${slug}/${index}.png`}
           alt={title}
-          className={`${hero ? "mask-b-from-75% mask-b-to-95%" : "mask-t-from-95% mask-t-to-100%"}`}
+          className={`${hero ? "mask-b-from-75% mask-b-to-95%" : "max-sm:mask-b-to-100% max-sm:mask-b-from-80% sm:mask-t-from-95% sm:mask-t-to-100%"}`}
         />
       </div>
     </Link>

--- a/app/components/nav-block.tsx
+++ b/app/components/nav-block.tsx
@@ -86,7 +86,6 @@ export default function NavBlock({
           src={`/posts/${slug}/${index}.png`}
           alt={title}
           className={`${hero ? "mask-b-from-75% mask-b-to-95%" : "mask-t-from-95% mask-t-to-100%"}`}
-          style={{ viewTransitionName: `post-visual-${slug}` }}
         />
       </div>
     </Link>

--- a/app/components/nav-block.tsx
+++ b/app/components/nav-block.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import { Link } from "react-router";
 import type { Post, VisualConfig } from "~/mdx/types";
 import { toUserIndex } from "~/utils/video-index";
 
@@ -25,9 +26,10 @@ export default function NavBlock({
   const elementRef = useRef<HTMLAnchorElement>(null);
 
   return (
-    <a
+    <Link
       ref={elementRef}
-      href={`${url}/${toUserIndex(index)}`}
+      to={`${url}/${toUserIndex(index)}`}
+      viewTransition
       style={
         {
           "--background": visual?.colors?.[index]?.background || "inherit",
@@ -35,7 +37,6 @@ export default function NavBlock({
         } as React.CSSProperties
       }
       className={`nav-block ${hero ? "justify-center" : "justify-between sm:flex-col"} flex-col-reverse @container text-[var(--text)] bg-[var(--background)] overflow-hidden flex group rounded-md relative ring-transparent ring-offset-1 dark:ring-offset-gray-950 hover:ring-[var(--background)] hover:ring-3 focus-visible:ring-[var(--background)] focus-visible:ring-3 outline-none transition-opacity duration-300 ${className}`}
-      rel="noreferrer"
     >
       <div
         className={`flex flex-col gap-4 p-4 ${hero ? "flex-0" : "h-auto flex-1 justify-between"}`}
@@ -85,8 +86,9 @@ export default function NavBlock({
           src={`/posts/${slug}/${index}.png`}
           alt={title}
           className={`${hero ? "mask-b-from-75% mask-b-to-95%" : "mask-t-from-95% mask-t-to-100%"}`}
+          style={{ viewTransitionName: `post-visual-${slug}` }}
         />
       </div>
-    </a>
+    </Link>
   );
 }

--- a/app/components/video-masthead.tsx
+++ b/app/components/video-masthead.tsx
@@ -64,6 +64,7 @@ export default function VideoMasthead({
             muted
             playsInline
             className="size-full"
+            style={{ viewTransitionName: `post-visual-${slug}` }}
             initial={hasChanged ? { x: "100%" } : false}
             animate={{ x: 0 }}
             exit={{ x: "-100%" }}

--- a/app/components/video-masthead.tsx
+++ b/app/components/video-masthead.tsx
@@ -65,7 +65,7 @@ export default function VideoMasthead({
             playsInline
             className="size-full"
             style={{ viewTransitionName: `post-visual-${slug}` }}
-            initial={hasChanged ? { x: "100%" } : false}
+            initial={hasChanged ? { x: "100%" } : undefined}
             animate={{ x: 0 }}
             exit={{ x: "-100%" }}
             transition={{ duration: 0.1 }}

--- a/app/global.css
+++ b/app/global.css
@@ -466,28 +466,108 @@ strong {
  * Supports morphing between index grid and post page
  */
 
-/* Root transition for overall page fade */
-::view-transition-old(root),
-::view-transition-new(root) {
-  animation-duration: 0.3s;
-  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-/* Disable root crossfade to only show morphing elements */
+/* Root transition - old disappears instantly, new fades in */
 ::view-transition-old(root) {
-  animation-name: none;
+  animation: none;
+  opacity: 0;
 }
 
 ::view-transition-new(root) {
-  animation-name: none;
+  animation: fade-in 0.3s ease-out;
 }
 
-/* Custom animation for post visuals (images/videos) morphing */
+/* Custom animation for post visuals (images/videos) */
 ::view-transition-old(post-visual),
 ::view-transition-new(post-visual) {
-  animation-duration: 0.4s;
-  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   /* Maintain aspect ratio during transition */
   object-fit: cover;
   overflow: clip;
+  mix-blend-mode: normal;
+}
+
+/* Completely disable group morphing for post visual */
+::view-transition-group(post-visual) {
+  /* No morphing animation at all */
+  animation: none !important;
+}
+
+/* New visual slides down from top and fades in */
+::view-transition-new(post-visual) {
+  animation: slideFromTop 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) 0.1s both,
+             fade-in 0.7s ease-out 0.1s both;
+  opacity: 0;
+  transform: translateY(-200px);
+}
+
+@keyframes slideFromTop {
+  from {
+    transform: translateY(-200px);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slideUpFade {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Post content elements - old disappears instantly, new fades in staggered */
+::view-transition-old(post-breadcrumb),
+::view-transition-old(post-metadata),
+::view-transition-old(post-content),
+::view-transition-old(post-visual) {
+  animation: none;
+  opacity: 0;
+}
+
+::view-transition-new(post-breadcrumb) {
+  animation: slideUpFade 0.5s ease-out 0.2s both;
+}
+
+::view-transition-new(post-metadata) {
+  animation: slideUpFade 0.5s ease-out 0.3s both;
+}
+
+::view-transition-new(post-content) {
+  animation: slideUpFade 0.5s ease-out 0.4s both;
+}
+
+/* Keep navigation fixed and prevent flickering during transitions */
+::view-transition-old(navigation),
+::view-transition-new(navigation) {
+  /* Keep navigation instantly visible with no animation */
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+/* Ensure navigation group doesn't animate and stays on top */
+::view-transition-group(navigation) {
+  animation-duration: 0s;
+  z-index: 9999;
 }

--- a/app/global.css
+++ b/app/global.css
@@ -456,3 +456,38 @@ strong {
 .nav-blocks-grid:has(.nav-block:hover, .nav-block:focus-visible) > .nav-block:not(:hover):not(:focus-visible) {
   opacity: 0.9;
 }
+
+/*************************************************************/
+/* View Transitions */
+/*************************************************************/
+
+/*
+ * View Transition API configuration for smooth page transitions
+ * Supports morphing between index grid and post page
+ */
+
+/* Root transition for overall page fade */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 0.3s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Disable root crossfade to only show morphing elements */
+::view-transition-old(root) {
+  animation-name: none;
+}
+
+::view-transition-new(root) {
+  animation-name: none;
+}
+
+/* Custom animation for post visuals (images/videos) morphing */
+::view-transition-old(post-visual),
+::view-transition-new(post-visual) {
+  animation-duration: 0.4s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  /* Maintain aspect ratio during transition */
+  object-fit: cover;
+  overflow: clip;
+}

--- a/app/mdx/types.ts
+++ b/app/mdx/types.ts
@@ -26,6 +26,7 @@ export interface Post {
   date?: Date;
   tags?: string[];
   frontmatter: PostFrontmatter;
+  excerpt?: string;
 }
 
 export interface ModelConfig {

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -60,7 +60,7 @@ export default function Index() {
                   hero={index === 0}
                   className={
                     index === 0
-                      ? "sm:col-span-2 3xl:col-span-3 sm:row-span-1 lg:row-span-2"
+                      ? "sm:col-span-2 3xl:col-span-3 sm:row-span-1 md:row-span-2"
                       : ""
                   }
                 />

--- a/app/routes/post.tsx
+++ b/app/routes/post.tsx
@@ -174,6 +174,7 @@ export default function Post() {
       <div className="flex flex-wrap gap-y-2 max-w-xl">
         <Link
           to="/"
+          viewTransition
           className="font-mono font-semibold group link-primary focus-ring-primary pr-2"
         >
           ❯ cd ~/code

--- a/app/routes/post.tsx
+++ b/app/routes/post.tsx
@@ -173,7 +173,7 @@ export default function Post() {
       )}
       <div
         className="flex flex-wrap gap-y-2 max-w-xl"
-        style={{ viewTransitionName: 'post-breadcrumb' }}
+        style={{ viewTransitionName: "post-breadcrumb" }}
       >
         <Link
           to="/"
@@ -191,7 +191,10 @@ export default function Post() {
         </h1>
       </div>
 
-      <Metadata data={metadata} style={{ viewTransitionName: 'post-metadata' }} />
+      <Metadata
+        data={metadata}
+        style={{ viewTransitionName: "post-metadata" }}
+      />
 
       {isOldArticle ? (
         <p className="font-mono rounded-md overflow-hidden border border-orange-200 dark:border-orange-800 text-orange-700 dark:text-orange-300 px-4 py-3 max-w-xl">
@@ -199,7 +202,7 @@ export default function Post() {
           information miiiiiight be out of date. Here be dragons, etc.
         </p>
       ) : null}
-      <div className="post" style={{ viewTransitionName: 'post-content' }}>
+      <div className="post" style={{ viewTransitionName: "post-content" }}>
         <Component />
       </div>
       {slug && (

--- a/app/routes/post.tsx
+++ b/app/routes/post.tsx
@@ -171,7 +171,10 @@ export default function Post() {
           visual={visual}
         />
       )}
-      <div className="flex flex-wrap gap-y-2 max-w-xl">
+      <div
+        className="flex flex-wrap gap-y-2 max-w-xl"
+        style={{ viewTransitionName: 'post-breadcrumb' }}
+      >
         <Link
           to="/"
           viewTransition
@@ -188,7 +191,7 @@ export default function Post() {
         </h1>
       </div>
 
-      <Metadata data={metadata} />
+      <Metadata data={metadata} style={{ viewTransitionName: 'post-metadata' }} />
 
       {isOldArticle ? (
         <p className="font-mono rounded-md overflow-hidden border border-orange-200 dark:border-orange-800 text-orange-700 dark:text-orange-300 px-4 py-3 max-w-xl">
@@ -196,7 +199,7 @@ export default function Post() {
           information miiiiiight be out of date. Here be dragons, etc.
         </p>
       ) : null}
-      <div className="post">
+      <div className="post" style={{ viewTransitionName: 'post-content' }}>
         <Component />
       </div>
       {slug && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1321,8 +1320,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250927.0.tgz",
       "integrity": "sha512-XcFVTMNhHROLQ+AbmK6KQuis72iGCdQXrjVl2xX98ac7w3fzUiNfTsu+SKBXN9dSEjgJEhhj0EXSAXh0b8lSww==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.19.0",
@@ -3194,8 +3192,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@stitches/core": {
       "version": "1.2.8",
@@ -3636,7 +3633,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -3713,7 +3711,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz",
       "integrity": "sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -3736,7 +3733,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3747,7 +3743,6 @@
       "integrity": "sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3997,7 +3992,6 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4238,7 +4232,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -4789,7 +4782,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -5603,9 +5597,9 @@
       }
     },
     "node_modules/inline-style-parser": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
-      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
     },
     "node_modules/intersection-observer": {
@@ -8181,6 +8175,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8196,6 +8191,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8206,6 +8202,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8285,7 +8282,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8304,7 +8300,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8356,7 +8351,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
       "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
-      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -8677,7 +8671,6 @@
       "version": "4.46.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.3.tgz",
       "integrity": "sha512-RZn2XTjXb8t5g13f5YclGoilU/kwT696DIkY3sywjdZidNSi3+vseaQov7D7BZXVJCPv3pDWUN69C78GGbXsKw==",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9257,12 +9250,12 @@
       "license": "MIT"
     },
     "node_modules/style-to-object": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
-      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
       "license": "MIT",
       "dependencies": {
-        "inline-style-parser": "0.2.4"
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -9375,8 +9368,7 @@
     "node_modules/tailwindcss": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.1.tgz",
-      "integrity": "sha512-QNbdmeS979Efzim2g/bEvfuh+fTcIdp1y7gA+sb6OYSW74rt7Cr7M78AKdf6HqWT3d5AiTb7SwTT3sLQxr4/qw==",
-      "peer": true
+      "integrity": "sha512-QNbdmeS979Efzim2g/bEvfuh+fTcIdp1y7gA+sb6OYSW74rt7Cr7M78AKdf6HqWT3d5AiTb7SwTT3sLQxr4/qw=="
     },
     "node_modules/tapable": {
       "version": "2.2.2",
@@ -9649,7 +9641,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9693,7 +9684,6 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.17.tgz",
       "integrity": "sha512-B06u0wXkEd+o5gOCMl/ZHl5cfpYbDZKAT+HWTL+Hws6jWu7dCiqBBXXXzMFcFVJb8D4ytAnYmxJA83uwOQRSsg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "exsolve": "^1.0.4",
@@ -9961,7 +9951,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.0.tgz",
       "integrity": "sha512-oLnWs9Hak/LOlKjeSpOwD6JMks8BeICEdYMJBf6P4Lac/pO9tKiv/XhXnAM7nNfSkZahjlCZu9sS50zL8fSnsw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10096,7 +10085,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -10287,7 +10275,6 @@
       "integrity": "sha512-POC8gGIAsJIYISxVe/oWIjSNwCqfaHMcDPzo6zuGTGvqYC33UM5WI82nULse1bNpXBC0L0XpqtHysW3sDqa8DQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.0",
         "@cloudflare/unenv-preset": "2.3.3",
@@ -10906,7 +10893,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
       "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- Added View Transitions API support for smooth page navigation
- Configured view transition names for nav and masthead elements
- Added CSS animations for fade and slide effects

## Test plan
- [ ] Test navigation between posts
- [ ] Verify smooth transitions in supporting browsers
- [ ] Check graceful degradation in unsupported browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)