### PR TITLE
add dependabot for actions and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Enables Dependabot for automated version updates:

- **github-actions** — weekly checks for action version updates (catches security patches, keeps SHA pins current if we move to those later)
- **npm** — weekly checks for dependency updates